### PR TITLE
Resolvendo problemas de string

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,11 +5,9 @@ Dir[File.join(File.dirname(__FILE__), 'commons/*.rb')].sort.each { |file| requir
 require 'rspec'
 require 'httparty'
 require 'pry'
-require 'faker'
-require 'cpf_faker'
 require 'logger'
 require 'brstring'
-require 'json_matchers/rspec'
+
 
 silence_warnings do
   OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
Foram retirados Requires do env.rb, para correção de problemas de Strings.